### PR TITLE
Adds a Dockerfile and a Docker Compose Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
+.vscode/
 __pycache__/
 
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# File  : Dockerfile
+# Date  : 18.09.2019
+# Author: Austin Schaffer <schaffer.austin.t@gmail.com>
+
 FROM python:3
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+
+EXPOSE 5000
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+ENV FLASK_APP=shhh
+COPY shhh shhh
+
+CMD [ "python", "-m", "flask", "run", "--host=0.0.0.0", "--port=5000" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Date  : 18.09.2019
 # Author: Austin Schaffer <schaffer.austin.t@gmail.com>
 
-FROM python:3
+FROM python:3-slim
 
 EXPOSE 5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       MYSQL_PASSWORD: shhh123
     volumes:
       - ./mysql/initialize.sql:/docker-entrypoint-initdb.d/initialize.sql
+      - mysql_data:/var/lib/mysql
     ports:
       - 3306:3306
 
@@ -41,3 +42,6 @@ services:
       - db
     ports:
       - 8080:8080
+
+volumes:
+  mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       USER_MYSQL: shhh
       PASS_MYSQL: shhh123
     ports:
-      - 80:5000
+      - 5000:5000
 
   adminer:
     image: adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # File  : docker-compose.yml
 # Author: Austin Schaffer <schaffer.austin.t@gmail.com>
+# Date  : 18.09.2019
 # Desc  : Describes the docker-compose configuration for development environments.
 #         These settings are not secure and are not intended for production use.
 #         Please override this configuration when configuring a production instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# File  : docker-compose.yml
+# Author: Austin Schaffer <schaffer.austin.t@gmail.com>
+# Desc  : Describes the docker-compose configuration for development environments.
+#         These settings are not secure and are not intended for production use.
+#         Please override this configuration when configuring a production instance.
+
+version: '3.2'
+
+services:
+  db:
+    image: mysql/mysql-server:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: 123456
+      MYSQL_DATABASE: shhh
+      MYSQL_USER: shhh
+      MYSQL_PASSWORD: shhh123
+    volumes:
+      - ./mysql/initialize.sql:/docker-entrypoint-initdb.d/initialize.sql
+    ports:
+      - 3306:3306
+
+  app:
+    image: smallwat3r/shhh:latest
+    build: .
+    depends_on:
+      - db
+    environment:
+      FLASK_ENV: development
+      HOST_MYSQL: db
+      DB_MYSQL: shhh
+      USER_MYSQL: shhh
+      PASS_MYSQL: shhh123
+    ports:
+      - 80:5000
+
+  adminer:
+    image: adminer
+    depends_on:
+      - db
+    ports:
+      - 8080:8080

--- a/mysql/initialize.sql
+++ b/mysql/initialize.sql
@@ -1,0 +1,20 @@
+-- -*- coding: utf-8 -*-
+-- File  : initialize.sql
+-- Author: Austin Schaffer <schaffer.austin.t@gmail.com>
+-- Desc  : Initializes tables, settings, and events for the MySQL instance.
+
+CREATE TABLE IF NOT EXISTS `links` (
+  `slug_link` text,
+  `passphrase` text,
+  `encrypted_text` text,
+  `date_created` datetime DEFAULT NULL,
+  `date_expires` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+SET GLOBAL event_scheduler = ON;
+
+CREATE EVENT IF NOT EXISTS AutoDeleteExpiredRecords
+ON SCHEDULE
+EVERY 2 HOUR
+DO
+  DELETE FROM `links` WHERE `date_expires` <= now();

--- a/mysql/initialize.sql
+++ b/mysql/initialize.sql
@@ -1,6 +1,7 @@
 -- -*- coding: utf-8 -*-
 -- File  : initialize.sql
 -- Author: Austin Schaffer <schaffer.austin.t@gmail.com>
+-- Date  : 18.09.2019
 -- Desc  : Initializes tables, settings, and events for the MySQL instance.
 
 CREATE TABLE IF NOT EXISTS `links` (

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ export PASS_MYSQL=<password>
 export DB_MYSQL=<name>
 ```
 
-Finally, run the below command to launch Shhh on localhost.
+Finally, run the below command to launch Shhh on http://localhost:5000/.
 
 ```sh
 $ python3 -m flask run --host='0.0.0.0'
@@ -80,14 +80,17 @@ $ python3 -m flask run --host='0.0.0.0'
 
 #### Docker Compose
 
-For development instances of this app, this repo contains a docker-compose
+For development instances of Shhh, this repo contains a docker-compose
 configuration. The configuration defines default settings for Shhh, as well as
-some default settings for a containerized instance of MySQL server. To run the
-app via docker-compose:
+some default settings for a containerized instance of MySQL server. To build and
+run Shhh via docker-compose:
 
 ```sh
 docker-compose up -d --build app
 ```
+
+Once the container image has finished building and starting, Shhh will be
+available via http://localhost:5000/.
 
 ## 💡 Idea credits  
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 Shhh is a tiny Flask App to write secrets and share them with people with a secure link.  
 The user can set up an expire date and a passphrase to access the secret.    
 
-Secrets and Passphrases are encypted in order to make the data anonymous, especially in MySQL.  
+Secrets and Passphrases are encrypted in order to make the data anonymous, especially in MySQL.  
 
 **Sender demo:**    
 ![Alt Text](https://github.com/smallwat3r/shhh/blob/master/demo/sender.gif)  
@@ -14,7 +14,8 @@ Secrets and Passphrases are encypted in order to make the data anonymous, especi
 
 ## ⚙️ Set up & Dependencies
 
-### MySql 
+### MySQL
+
 Create a MySQL database and run the following script to generate the table `links` that will store our data.
 
 ```sql
@@ -27,15 +28,14 @@ CREATE TABLE `links` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-We need to make sure the `event_scheduler` in MySql is activated to schedule database clean-ups (in order to remove the records that has expired).
-
-In MySQL run the following to activate the `event_scheduler`
+In MySQL run the following to activate the `event_scheduler`. We need to make sure the `event_scheduler` is activated to schedule database clean-ups (in order to remove the records that has expired).
 
 ```sql
 SET GLOBAL event_scheduler = ON;
 ```
 
 Then we need to schedule a run at least every 2 hours to remove our expired records.
+
 ```sql
 CREATE EVENT AutoDeleteExpiredRecords
 ON SCHEDULE
@@ -44,8 +44,12 @@ DO
   DELETE FROM links WHERE date_expires <= now();
 ```
 
+These MySQL queries can also be executed from the `mysql/initialize.sql` file.
+
 ### Launch Shhh in local
+
 We need to create a virtual environment, enter it, and install the needed dependencies.
+
 ```sh
 $ virtualenv -p python3 venv --no-site-package
 $ source venv/bin/activate
@@ -53,7 +57,8 @@ $ pip install -r requirements.txt
 ```
 
 We then need to set-up our Environment Variables.
-```
+
+```sh
 export FLASK_APP=shhh
 export FLASK_ENV=<development/production>
 export HOST_MYSQL=<localhost>
@@ -61,6 +66,7 @@ export USER_MYSQL=<username>
 export PASS_MYSQL=<password>
 export DB_MYSQL=<name>
 ```
+
 Then run the below command to launch Shhh in local.
 
 ```sh

--- a/readme.md
+++ b/readme.md
@@ -55,9 +55,9 @@ We recommend that you create a virtual environment for this project, so you can
 install the required dependencies.
 
 ```sh
-$ virtualenv -p python3 venv --no-site-package
-$ source venv/bin/activate
-$ pip install -r requirements.txt
+virtualenv -p python3 venv --no-site-package
+source venv/bin/activate
+pip install -r requirements.txt
 ```
 
 You then need to set up a few environment variables. These will be used to
@@ -75,7 +75,7 @@ export DB_MYSQL=<name>
 Finally, run the below command to launch Shhh on http://localhost:5000/.
 
 ```sh
-$ python3 -m flask run --host='0.0.0.0'
+python3 -m flask run --host='0.0.0.0'
 ```
 
 #### Docker Compose

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ CREATE TABLE `links` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-In MySQL run the following to activate the `event_scheduler`. We need to make sure the `event_scheduler` is activated to schedule database clean-ups (in order to remove the records that has expired).
+In MySQL run the following to activate the `event_scheduler`. We need to make sure the `event_scheduler` is activated to schedule database clean-ups (in order to remove the records that have expired).
 
 ```sql
 SET GLOBAL event_scheduler = ON;
@@ -44,11 +44,15 @@ DO
   DELETE FROM links WHERE date_expires <= now();
 ```
 
-These MySQL queries can also be executed from the `mysql/initialize.sql` file.
+These MySQL queries can also be executed against the MySQL server instance via
+the `mysql/initialize.sql` file.
 
-### Launch Shhh in local
+### Launch Shhh
 
-We need to create a virtual environment, enter it, and install the needed dependencies.
+#### Natively Using Flask
+
+We recommend that you create a virtual environment for this project, so you can
+install the required dependencies.
 
 ```sh
 $ virtualenv -p python3 venv --no-site-package
@@ -56,7 +60,8 @@ $ source venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
-We then need to set-up our Environment Variables.
+You then need to set up a few environment variables. These will be used to
+configure Flask, as well as the app's connection to an instance of MySQL.
 
 ```sh
 export FLASK_APP=shhh
@@ -67,10 +72,21 @@ export PASS_MYSQL=<password>
 export DB_MYSQL=<name>
 ```
 
-Then run the below command to launch Shhh in local.
+Finally, run the below command to launch Shhh on localhost.
 
 ```sh
 $ python3 -m flask run --host='0.0.0.0'
+```
+
+#### Docker Compose
+
+For development instances of this app, this repo contains a docker-compose
+configuration. The configuration defines default settings for Shhh, as well as
+some default settings for a containerized instance of MySQL server. To run the
+app via docker-compose:
+
+```sh
+docker-compose up -d --build app
 ```
 
 ## 💡 Idea credits  


### PR DESCRIPTION
Adds a `Dockerfile` and a `docker-compose.yml`, allowing the application to be run in a local container using `docker-compose up -d --build app`.

The Dockerfile defines a container image build for the application, using the `python:3-slim` base image.

The docker-compose configuration is intended for development instances only. For production, it is recommended that the compose configuration should be overridden with settings that are more secure. This configuration defines 3 services, with default configurations

- `app`: a Flask app container serving an instance of "Shhh"
- `db`: MySQL Server 5.7, for storing the app's data
- `adminer`: Optional service for querying the MySQL instance from the browser

Recommended merge strategy: squash

Closes #3
