### PR TITLE
Standardize secret newline characters

### DIFF
--- a/shhh/api/api.py
+++ b/shhh/api/api.py
@@ -3,7 +3,7 @@ import functools
 
 from flask import Blueprint, Response, make_response
 from flask.views import MethodView
-from marshmallow import Schema, fields, validates_schema
+from marshmallow import Schema, fields, pre_load, validates_schema
 from webargs.flaskparser import abort, parser, use_kwargs
 
 from shhh.api.handlers import parse_error, read_secret, write_secret
@@ -33,6 +33,12 @@ class PostParams(Schema):
     days = fields.Int(validate=Validator.days)
     tries = fields.Int(validate=Validator.tries)
     haveibeenpwned = fields.Bool()
+
+    @pre_load
+    def standardize_newline_characters(self, data, **kwargs):
+        """Standardize newline character from secret."""
+        data["secret"] = "\n".join(data["secret"].splitlines())
+        return data
 
     @validates_schema
     def haveibeenpwned_checker(self, data, **kwargs):

--- a/shhh/api/api.py
+++ b/shhh/api/api.py
@@ -35,7 +35,7 @@ class PostParams(Schema):
     haveibeenpwned = fields.Bool()
 
     @pre_load
-    def standardize_newline_characters(self, data, **kwargs):
+    def standardize_newline_character(self, data, **kwargs):
         """Standardize newline character from secret."""
         data["secret"] = "\n".join(data["secret"].splitlines())
         return data

--- a/shhh/api/api.py
+++ b/shhh/api/api.py
@@ -37,7 +37,8 @@ class PostParams(Schema):
     @pre_load
     def standardize_newline_character(self, data, **kwargs):
         """Standardize newline character from secret."""
-        data["secret"] = "\n".join(data["secret"].splitlines())
+        if data.get("secret") and isinstance(data.get("secret"), str):
+            data["secret"] = "\n".join(data["secret"].splitlines())
         return data
 
     @validates_schema


### PR DESCRIPTION
Make sure the newline characters are always interpreted as one character: `\n`.

Some browsers (Chrome) sent the secrets with newlines of two characters `\r\n`, which made the secret lenght limit to be triggered from the server but not the UI.

Fixes #185 